### PR TITLE
this.session not defined

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -779,10 +779,6 @@ BOOMR_check_doc_domain();
 				return this;
 			}
 
-			if (config.site_domain !== undefined) {
-				this.session.domain = config.site_domain;
-			}
-
 			if (config.log !== undefined) {
 				this.log = config.log;
 			}


### PR DESCRIPTION
error thrown as 'this.session' is undefined, when site_domain is provided as an option from config.
looking at the code this.session.domain is not used anywhere, so removing its ref.