### PR TITLE
Fix npm error running webdriver-manager when it's not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "test": "grunt test",
-    "install": "node node_modules/protractor/bin/webdriver-manager update"
+    "install": "if [ -e node_modules/protractor/bin/webdriver-manager ]; then node node_modules/protractor/bin/webdriver-manager update; fi"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running `npm install https://github.com/SOASTA/boomerang` the install script throws an error and fails because webdriver-manager does not exist. This update checks for the existence of webdriver-manager before attempting to run it.

Here is the error
```
npm ERR! boomerang@0.9.0 install: `node node_modules/protractor/bin/webdriver-manager update`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the boomerang@0.9.0 install script 'node node_modules/protractor/bin/webdriver-manager update'.
npm ERR! This is most likely a problem with the boomerang package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node node_modules/protractor/bin/webdriver-manager update
npm ERR! You can get their info via:
npm ERR!     npm owner ls boomerang
npm ERR! There is likely additional logging output above.
```