### PR TITLE
Strict mode compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 hint.log
 *.log
 *.diff
+.idea
 .project
 .settings/
 tests/vendor/
@@ -20,3 +21,4 @@ npm-debug.log
 *.#*
 *#*
 *~
+

--- a/boomerang.js
+++ b/boomerang.js
@@ -19,9 +19,8 @@ you, but we have a few ideas.
 // Measure the time the script started
 // This has to be global so that we don't wait for the entire
 // BOOMR function to download and execute before measuring the
-// time.  We also declare it without `var` so that we can later
-// `delete` it.  This is the only way that works on Internet Explorer
-BOOMR_start = new Date().getTime();
+// time.
+window.BOOMR_start = new Date().getTime();
 
 /**
  Check the value of document.domain and fix it if incorrect.
@@ -1303,11 +1302,11 @@ BOOMR_check_doc_domain();
 
 	};
 
-	delete BOOMR_start;
+	delete window.BOOMR_start;
 
 	if (typeof BOOMR_lstart === "number") {
 		boomr.t_lstart = BOOMR_lstart;
-		delete BOOMR_lstart;
+		delete window.BOOMR_lstart;
 	}
 	else if (typeof BOOMR.window.BOOMR_lstart === "number") {
 		boomr.t_lstart = BOOMR.window.BOOMR_lstart;


### PR DESCRIPTION
When bundling the boomerang script with an application that is running JavaScript in strict mode, some bundlers balk at the illegal use of `delete` with a "local variable." By explicitly using `window` in declarations and deletions, this gets past static checker grumpiness.