### PR TITLE
Add missing Mocha dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-safari-launcher": "^0.1.1",
     "karma-tap-reporter": "0.0.3",
+    "mocha": "3.0.2",
     "phantomjs": "^1.9.13",
     "protractor": "^1.3.1",
     "strip-json-comments": "^1.0.2"


### PR DESCRIPTION
Mocha is used as the test runner via `karma-mocha`. `karma-mocha` relies
on the availability of mocha as a peer dependency, but boomerang does
not define mocha as a dev dependency.