### PR TITLE
Update README to account for changed build procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ You could also include any other code you need.  For example, I include a timer 
 
 I call my plugin `zzz_init.js` to remind me to include it last in the plugin list
 
-### 2. Build boomerang using this plugin as the last one
+### 2. Build boomerang
+The build process picks up all the plugins referenced in the `plugins.json` file. To change the plugins included in the boomerang build, change the contents of the file to your needs.
 
 ```bash
-make PLUGINS="list.js of.js plugins.js zzz_init.js" MINIFIER="/path/to/your/js-minifier"
+grunt clean build
 ```
 
-This should create `boomerang-<version>.js`
+This creates deployable boomerang versions in the `build` directory, e.g. `build/boomerang-<version>.min.js`.
 
 Install this file on your web server or origin server where your CDN can pick it up.  Set a far future max-age header for it.  This file will never change.
 

--- a/package.json
+++ b/package.json
@@ -174,6 +174,10 @@
     {
       "name": "Andreas Marschke",
       "email": "andreas.marschke@gmail.com"
+    },
+    {
+      "name": "Ben Ripkens",
+      "email": "bripkens@gmail.com"
     }
   ],
   "license": "BSD-3-Clause",


### PR DESCRIPTION
The build process was changed as part of the last big soasta contributions. We should update the docs to reflect the switch from Make to a Grunt based build process.