### PR TITLE
Make the errors plugin work without the Compression plugin

### DIFF
--- a/plugins/errors.js
+++ b/plugins/errors.js
@@ -780,11 +780,11 @@ if (!Array.isArray) {
 		getErrorsForUrl: function(errors) {
 			errors = impl.compressErrors(errors);
 
-			if (BOOMR.utils.Compression.jsUrl) {
+			if (BOOMR.utils.Compression && BOOMR.utils.Compression.jsUrl) {
 				return BOOMR.utils.Compression.jsUrl(errors);
 			}
 			else if (window.JSON) {
-				url += JSON.stringify(errors);
+				return JSON.stringify(errors);
 			}
 			else {
 				// not supported


### PR DESCRIPTION
Without the compression plugin, you can't directly try to access
Compression.jsUrl and must first check for Compression itself. And
getErrorsForUrl should return the serialized errors.