### PR TITLE
Compare marks/measures to performance.now mark

### DIFF
--- a/plugins/usertiming.js
+++ b/plugins/usertiming.js
@@ -27,13 +27,41 @@
 		options: {"from": 0, "window": BOOMR.window},
 
 		/**
+		 * Get a timestamp to compare with performance marks and measures.
+		 *
+		 * This function needs to approximate the time since the Navigation Timing API's
+		 * `navigationStart` time. If available, `performance.now()` can provide this
+		 * value. If not we either get the navigation start time from the RT plugin or
+		 * from `t_lstart` or `t_start`. Those values are subtracted from the current
+		 * time to derive a time since `navigationStart` value.
+		 *
+		 * @returns {float} Exact or approximate time since navigation start.
+		 */
+		now: function() {
+			var now, navigationStart, p = BOOMR.getPerformance();
+
+			if (p && p.now) {
+				now = p.now();
+			}
+			else {
+				navigationStart = (BOOMR.plugins.RT && BOOMR.plugins.RT.navigationStart) ?
+					BOOMR.plugins.RT.navigationStart() :
+					(BOOMR.t_lstart || BOOMR.t_start);
+
+				now = BOOMR.now() - navigationStart;
+			}
+
+			return now;
+		},
+
+		/**
 		 * Calls the UserTimingCompression library to get the compressed user timing data
 		 * that occurred since the last call
 		 *
 		 * @returns {string} compressed user timing data
 		 */
 		getUserTiming: function() {
-			var timings, res, now = BOOMR.now();
+			var timings, res, now = this.now();
 			var utc = window.UserTimingCompression || BOOMR.window.UserTimingCompression;
 
 			timings = utc.getCompressedUserTiming(impl.options);

--- a/tests/page-templates/18-usertiming/04-usertiming-second-beacon.html
+++ b/tests/page-templates/18-usertiming/04-usertiming-second-beacon.html
@@ -1,0 +1,29 @@
+<%= header %>
+<%= boomerangSnippet %>
+<script src="04-usertiming-second-beacon.js" type="text/javascript"></script>
+<script src="../../vendor/usertiming-compression/src/usertiming-decompression.js" type="text/javascript"></script>
+<script>
+	if (BOOMR_test.isUserTimingSupported()) {
+		window.performance.mark("pre-load-mark-start");
+		window.performance.mark("pre-load-mark-end");
+		window.performance.measure("pre-load-measure", "pre-load-mark-start", "pre-load-mark-end");
+	}
+
+	function sendPostLoadMark() {
+		if (BOOMR_test.isUserTimingSupported()) {
+			window.performance.mark("post-load-mark-start");
+			window.performance.mark("post-load-mark-end");
+			window.performance.measure("post-load-measure", "post-load-mark-start", "post-load-mark-end");
+			BOOMR.responseEnd("test");
+		}
+	}
+
+	BOOMR_test.init({
+		testAfterOnBeacon: BOOMR_test.isUserTimingSupported() ? 2 : 1,
+		UserTiming: {
+			enabled: true
+		},
+		afterFirstBeacon: sendPostLoadMark
+	});
+</script>
+<%= footer %>

--- a/tests/page-templates/18-usertiming/04-usertiming-second-beacon.js
+++ b/tests/page-templates/18-usertiming/04-usertiming-second-beacon.js
@@ -1,0 +1,55 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/17-usertiming/04-usertiming-second-beacon", function() {
+	var t = BOOMR_test;
+	var tf = BOOMR.plugins.TestFramework;
+
+	it("Should pass basic beacon validation", function(done) {
+		t.validateBeaconWasSent(done);
+	});
+
+	it("Should receive user timing data for marks/measures set before load beacon only", function() {
+		if (t.isUserTimingSupported()) {
+			var b = tf.beacons[0];
+			assert.isString(b.usertiming);
+
+			var data = UserTimingDecompression.decompressUserTiming(b.usertiming);
+			var usertiming = {};
+
+			for (var i = 0; i < data.length; i++) {
+				usertiming[data[i].name] = data[i];
+			}
+
+			assert.isTrue("pre-load-mark-start" in usertiming);
+			assert.isTrue("pre-load-mark-end" in usertiming);
+			assert.isTrue("pre-load-measure" in usertiming);
+
+			assert.isFalse("post-load-mark-start" in usertiming);
+			assert.isFalse("post-load-mark-end" in usertiming);
+			assert.isFalse("post-load-measure" in usertiming);
+		}
+	});
+
+	it("Should receive user timing data for marks/measures set before post-load beacon only", function() {
+		if (t.isUserTimingSupported()) {
+			var b = tf.beacons[1];
+			assert.isString(b.usertiming);
+
+			var data = UserTimingDecompression.decompressUserTiming(b.usertiming);
+			var usertiming = {};
+
+			for (var i = 0; i < data.length; i++) {
+				usertiming[data[i].name] = data[i];
+			}
+
+			assert.isTrue("post-load-mark-start" in usertiming);
+			assert.isTrue("post-load-mark-end" in usertiming);
+			assert.isTrue("post-load-measure" in usertiming);
+
+			assert.isFalse("pre-load-mark-start" in usertiming);
+			assert.isFalse("pre-load-mark-end" in usertiming);
+			assert.isFalse("pre-load-measure" in usertiming);
+		}
+	});
+});

--- a/tests/page-templates/18-usertiming/05-usertiming-second-beacon-no-performance-now.html
+++ b/tests/page-templates/18-usertiming/05-usertiming-second-beacon-no-performance-now.html
@@ -1,0 +1,34 @@
+<%= header %>
+<%= boomerangSnippet %>
+<script>
+	if (window.performance) {
+		window.performance.now = undefined;
+	}
+</script>
+<script src="05-usertiming-second-beacon-no-performance-now.js" type="text/javascript"></script>
+<script src="../../vendor/usertiming-compression/src/usertiming-decompression.js" type="text/javascript"></script>
+<script>
+	if (BOOMR_test.isUserTimingSupported()) {
+		window.performance.mark("pre-load-mark-start");
+		window.performance.mark("pre-load-mark-end");
+		window.performance.measure("pre-load-measure", "pre-load-mark-start", "pre-load-mark-end");
+	}
+
+	function sendPostLoadMark() {
+		if (BOOMR_test.isUserTimingSupported()) {
+			window.performance.mark("post-load-mark-start");
+			window.performance.mark("post-load-mark-end");
+			window.performance.measure("post-load-measure", "post-load-mark-start", "post-load-mark-end");
+			BOOMR.responseEnd("test");
+		}
+	}
+
+	BOOMR_test.init({
+		testAfterOnBeacon: BOOMR_test.isUserTimingSupported() ? 2 : 1,
+		UserTiming: {
+			enabled: true
+		},
+		afterFirstBeacon: sendPostLoadMark
+	});
+</script>
+<%= footer %>

--- a/tests/page-templates/18-usertiming/05-usertiming-second-beacon-no-performance-now.js
+++ b/tests/page-templates/18-usertiming/05-usertiming-second-beacon-no-performance-now.js
@@ -1,0 +1,55 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/17-usertiming/05-usertiming-second-beacon-no-performance-now", function() {
+	var t = BOOMR_test;
+	var tf = BOOMR.plugins.TestFramework;
+
+	it("Should pass basic beacon validation", function(done) {
+		t.validateBeaconWasSent(done);
+	});
+
+	it("Should receive user timing data for marks/measures set before load beacon only", function() {
+		if (t.isUserTimingSupported()) {
+			var b = tf.beacons[0];
+			assert.isString(b.usertiming);
+
+			var data = UserTimingDecompression.decompressUserTiming(b.usertiming);
+			var usertiming = {};
+
+			for (var i = 0; i < data.length; i++) {
+				usertiming[data[i].name] = data[i];
+			}
+
+			assert.isTrue("pre-load-mark-start" in usertiming);
+			assert.isTrue("pre-load-mark-end" in usertiming);
+			assert.isTrue("pre-load-measure" in usertiming);
+
+			assert.isFalse("post-load-mark-start" in usertiming);
+			assert.isFalse("post-load-mark-end" in usertiming);
+			assert.isFalse("post-load-measure" in usertiming);
+		}
+	});
+
+	it("Should receive user timing data for marks/measures set before post-load beacon only", function() {
+		if (t.isUserTimingSupported()) {
+			var b = tf.beacons[1];
+			assert.isString(b.usertiming);
+
+			var data = UserTimingDecompression.decompressUserTiming(b.usertiming);
+			var usertiming = {};
+
+			for (var i = 0; i < data.length; i++) {
+				usertiming[data[i].name] = data[i];
+			}
+
+			assert.isTrue("post-load-mark-start" in usertiming);
+			assert.isTrue("post-load-mark-end" in usertiming);
+			assert.isTrue("post-load-measure" in usertiming);
+
+			assert.isFalse("pre-load-mark-start" in usertiming);
+			assert.isFalse("pre-load-mark-end" in usertiming);
+			assert.isFalse("pre-load-measure" in usertiming);
+		}
+	});
+});


### PR DESCRIPTION
When using the User Timing API plugin, only the first beacon sent will include User Timing API data. Subsequent beacons will not collect newly set User Timing API data due to comparing incorrect timestamps.

To reproduce:

1. Add code to a test page running Boomerang and the User Timing API plugin. Something like the following would suffice:

   ```
   performance.mark('pre-load-mark');

   addEventListener('load', () => {
     setTimeout(() => {
       console.log('marking');
       performance.mark('post-load-mark');
     }, 5000);
   });
   ```

2. Load the page with Boomerang, the User Timing API plugin and the sample code
3. After the `load` event fires, inspect the Network tab to see that a beacon was sent with the User Timing API data, including the 'pre-load-mark' mark. The 'post-load-mark' should not be present.
4. Fire another beacon from the console  with: `BOOMR.requestStart('test').loaded();`
5. Notice that the expected 'post-load-mark' is not present in the beacon.

On line [41 in plugins/usertiming.js](https://github.com/SOASTA/boomerang/blob/master/plugins/usertiming.js#L41), the `from` value is set to `BOOMR.now()`. This value is a millisecond timestamp derived from `Date.now()`. When subsequent beacons are fired, the mark/measure's `startTime + duration` is [compared](https://github.com/nicjansma/usertiming-compression.js/blob/master/src/usertiming-compression.js#L388) to the `from` timestamp. Since the mark/measure is using
`performance.now()` instead of `Date.now()` to set the time, the value will always be less than the `Date.now()` timestamp. Thus, the data is considered old and is removed from the compressed data.

The fix for the issue is to use `performance.now()` instead of `Date.now()` when setting the `from` value. Since this function isn't called unless the User Timing API is available, it should be safe to directly call `performance.now()` without any defensive coding.