### PR TITLE
Add support for Network Information API

### DIFF
--- a/plugins/mobile.js
+++ b/plugins/mobile.js
@@ -52,7 +52,7 @@ Plugin to capture navigator.connection.type on browsers that support it
 				connection.addEventListener("change", function() {
 					this.setConnectionInformation();
 					BOOMR.fireEvent("netinfo", connection);
-				});
+				}.bind(this));
 			}
 		},
 

--- a/plugins/mobile.js
+++ b/plugins/mobile.js
@@ -4,7 +4,21 @@ Plugin to capture navigator.connection.type on browsers that support it
 */
 
 (function() {
-	var connection;
+	var connection, param_map = {
+		"type": "ct",
+		"bandwidth": "bw",
+		"metered": "mt",
+		"effectiveType": "etype",
+		"downlinkMax": "lm",
+		"downlink": "dl",
+		"rtt": "rtt"
+	};
+
+	BOOMR = window.BOOMR || {};
+
+	if (typeof BOOMR.addVar !== "function") {
+		return;
+	}
 
 	if (typeof navigator === "object") {
 		connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
@@ -13,13 +27,28 @@ Plugin to capture navigator.connection.type on browsers that support it
 	if (!connection) {
 		return;
 	}
-	BOOMR.addVar({
-		"mob.ct": connection.type,
-		"mob.bw": connection.bandwidth,
-		"mob.mt": connection.metered
-	});
 
-	if (connection.downlinkMax) {
-		BOOMR.addVar("mob.lm", connection.downlinkMax);
+	function setVars() {
+		var k;
+
+		for (k in param_map) {
+			if (k in connection) {
+				// Remove old parameter value from the beacon because new value might be falsey which won't overwrite old value
+				BOOMR.removeVar("mob." + param_map[k]);
+				if (connection[k]) {
+					BOOMR.addVar("mob." + param_map[k], connection[k]);
+				}
+			}
+		}
 	}
+
+	// If connection information changes, we collect the latest values
+	if (connection.addEventListener) {
+		connection.addEventListener("change", function() {
+			setVars();
+			BOOMR.fireEvent("netinfo", connection);
+		});
+	}
+
+	setVars();
 }());

--- a/plugins/mobile.js
+++ b/plugins/mobile.js
@@ -65,7 +65,7 @@ Plugin to capture navigator.connection.type on browsers that support it
 		 * @returns {void}
 		 */
 		setConnectionInformation: function() {
-			var k, connection, param_map = this.param_map;
+			var k, connection, type, param_map = this.param_map;
 
 			connection = this.getConnection();
 
@@ -73,7 +73,9 @@ Plugin to capture navigator.connection.type on browsers that support it
 				if (k in connection) {
 					// Remove old parameter value from the beacon because new value might be falsey which won't overwrite old value
 					BOOMR.removeVar("mob." + param_map[k]);
-					if (connection[k]) {
+
+					type = typeof connection[k];
+					if (type === "number" || type === "string" || type === "boolean") {
 						BOOMR.addVar("mob." + param_map[k], connection[k]);
 					}
 				}

--- a/plugins/mobile.js
+++ b/plugins/mobile.js
@@ -50,9 +50,9 @@ Plugin to capture navigator.connection.type on browsers that support it
 
 			if (connection.addEventListener) {
 				connection.addEventListener("change", function() {
-					this.setConnectionInformation();
+					impl.setConnectionInformation();
 					BOOMR.fireEvent("netinfo", connection);
-				}.bind(this));
+				});
 			}
 		},
 

--- a/plugins/mobile.js
+++ b/plugins/mobile.js
@@ -4,51 +4,98 @@ Plugin to capture navigator.connection.type on browsers that support it
 */
 
 (function() {
-	var connection, param_map = {
-		"type": "ct",
-		"bandwidth": "bw",
-		"metered": "mt",
-		"effectiveType": "etype",
-		"downlinkMax": "lm",
-		"downlink": "dl",
-		"rtt": "rtt"
-	};
-
 	BOOMR = window.BOOMR || {};
+	BOOMR.plugins = BOOMR.plugins || {};
 
-	if (typeof BOOMR.addVar !== "function") {
-		return;
-	}
+	var impl = {
+		connection: null,
+		param_map: {
+			"type": "ct",
+			"bandwidth": "bw",
+			"metered": "mt",
+			"effectiveType": "etype",
+			"downlinkMax": "lm",
+			"downlink": "dl",
+			"rtt": "rtt",
+			"saveData": "sd"
+		},
 
-	if (typeof navigator === "object") {
-		connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
-	}
+		/**
+		 * Get the connection information object if available.
+		 *
+		 * @returns {null|NavigatorNetworkInformation} The network information API data.
+		 */
+		getConnection: function() {
+			if (this.connection) {
+				return this.connection;
+			}
 
-	if (!connection) {
-		return;
-	}
+			if (typeof navigator === "object") {
+				this.connection = navigator.connection ||
+					navigator.mozConnection ||
+					navigator.webkitConnection ||
+					navigator.msConnection;
+			}
 
-	function setVars() {
-		var k;
+			return this.connection;
+		},
 
-		for (k in param_map) {
-			if (k in connection) {
-				// Remove old parameter value from the beacon because new value might be falsey which won't overwrite old value
-				BOOMR.removeVar("mob." + param_map[k]);
-				if (connection[k]) {
-					BOOMR.addVar("mob." + param_map[k], connection[k]);
+		/**
+		 * Add listener to update network information when it changes.
+		 *
+		 * @returns {void}
+		 */
+		subscribe: function() {
+			var connection = this.getConnection();
+
+			if (connection.addEventListener) {
+				connection.addEventListener("change", function() {
+					this.setConnectionInformation();
+					BOOMR.fireEvent("netinfo", connection);
+				});
+			}
+		},
+
+		/**
+		 * Set connection information.
+		 *
+		 * Uses information from the Network Information API to add variable to the beacon. This data is set once the plugin
+		 * is initiated and is only updated if the network information changes.
+		 *
+		 * @returns {void}
+		 */
+		setConnectionInformation: function() {
+			var k, connection, param_map = this.param_map;
+
+			connection = this.getConnection();
+
+			for (k in param_map) {
+				if (k in connection) {
+					// Remove old parameter value from the beacon because new value might be falsey which won't overwrite old value
+					BOOMR.removeVar("mob." + param_map[k]);
+					if (connection[k]) {
+						BOOMR.addVar("mob." + param_map[k], connection[k]);
+					}
 				}
 			}
 		}
-	}
+	};
 
-	// If connection information changes, we collect the latest values
-	if (connection.addEventListener) {
-		connection.addEventListener("change", function() {
-			setVars();
-			BOOMR.fireEvent("netinfo", connection);
-		});
-	}
+	BOOMR.plugins.Mobile = {
+		init: function() {
+			var connection = impl.getConnection();
 
-	setVars();
+			// Only get information if we have a source for the information
+			if (connection) {
+				impl.setConnectionInformation();
+				impl.subscribe();
+			}
+
+			return this;
+		},
+
+		is_complete: function() {
+			return true;
+		}
+	};
 }());

--- a/tests/boomerang-test-framework.js
+++ b/tests/boomerang-test-framework.js
@@ -285,6 +285,14 @@
 		        typeof window.performance.measure === "function");
 	};
 
+	t.isNetworkAPISupported = function() {
+		return (navigator && typeof navigator === "object" &&
+			navigator.connection ||
+			navigator.mozConnection ||
+			navigator.webkitConnection ||
+			navigator.msConnection);
+	};
+
 	t.validateBeaconWasImg = function(done) {
 		if (!t.isResourceTimingSupported()) {
 			// need RT to validate

--- a/tests/page-templates/19-mobile/00-mobile-basic.html
+++ b/tests/page-templates/19-mobile/00-mobile-basic.html
@@ -1,0 +1,9 @@
+<%= header %>
+<%= boomerangSnippet %>
+<script src="00-mobile-basic.js" type="text/javascript"></script>
+<script>
+	BOOMR_test.init({
+		testAfterOnBeacon: true
+	});
+</script>
+<%= footer %>

--- a/tests/page-templates/19-mobile/00-mobile-basic.js
+++ b/tests/page-templates/19-mobile/00-mobile-basic.js
@@ -1,0 +1,25 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/19-mobile/00-mobile-basic", function() {
+	var t = BOOMR_test;
+	var tf = BOOMR.plugins.TestFramework;
+
+	it("Should pass basic beacon validation", function(done) {
+		t.validateBeaconWasSent(done);
+	});
+
+	it("Should have at least one key starting with mob", function() {
+		if (t.isNetworkAPISupported()) {
+			var k, actual = false, b = tf.beacons[0];
+
+			for (k in b) {
+				if (k.indexOf("mob") === 0) {
+					actual = true;
+				}
+			}
+
+			assert.isTrue(actual);
+		}
+	});
+});

--- a/tests/page-templates/19-mobile/01-mobile-variable-mapping.html
+++ b/tests/page-templates/19-mobile/01-mobile-variable-mapping.html
@@ -1,0 +1,9 @@
+<%= header %>
+<%= boomerangSnippet %>
+<script src="01-mobile-variable-mapping.js" type="text/javascript"></script>
+<script>
+	BOOMR_test.init({
+		testAfterOnBeacon: true
+	});
+</script>
+<%= footer %>

--- a/tests/page-templates/19-mobile/01-mobile-variable-mapping.js
+++ b/tests/page-templates/19-mobile/01-mobile-variable-mapping.js
@@ -1,0 +1,116 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/19-mobile/01-mobile-variable-mapping", function() {
+	var t = BOOMR_test;
+	var tf = BOOMR.plugins.TestFramework;
+
+	it("Should pass basic beacon validation", function(done) {
+		t.validateBeaconWasSent(done);
+	});
+
+	it("Should map type to ct when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "type" in connection) {
+				assert.isTrue("mob.ct" in b);
+				assert.isTrue(b["mob.ct"] === connection.type);
+			}
+		}
+	});
+
+	it("Should map bandwidth to bw when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "bandwidth" in connection) {
+				assert.isTrue("mob.bw" in b);
+				assert.isTrue(b["mob.bw"] === connection.bandwidth);
+			}
+		}
+	});
+
+	it("Should map metered to mt when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "metered" in connection) {
+				assert.isTrue("mob.mt" in b);
+				assert.isTrue(b["mob.mt"] === connection.metered);
+			}
+		}
+	});
+
+	it("Should map effectiveType to etype when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "effectiveType" in connection) {
+				assert.isTrue("mob.etype" in b);
+				assert.isTrue(b["mob.etype"] === connection.effectiveType);
+			}
+		}
+	});
+
+	it("Should map downlinkMax to lm when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "downlinkMax" in connection) {
+				assert.isTrue("mob.lm" in b);
+				assert.isTrue(b["mob.lm"] === connection.downlinkMax);
+			}
+		}
+	});
+
+	it("Should map downlink to dl when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "downlink" in connection) {
+				assert.isTrue("mob.dl" in b);
+				assert.isTrue(b["mob.dl"] === connection.downlink);
+			}
+		}
+	});
+
+	it("Should map rtt to rtt when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "rtt" in connection) {
+				assert.isTrue("mob.rtt" in b);
+				assert.isTrue(b["mob.rtt"] === connection.rtt);
+			}
+		}
+	});
+});

--- a/tests/page-templates/19-mobile/01-mobile-variable-mapping.js
+++ b/tests/page-templates/19-mobile/01-mobile-variable-mapping.js
@@ -113,4 +113,19 @@ describe("e2e/19-mobile/01-mobile-variable-mapping", function() {
 			}
 		}
 	});
+
+	it("Should map saveData to sd when available", function() {
+		if (t.isNetworkAPISupported()) {
+			var connection, b = tf.beacons[0];
+
+			if (typeof navigator === "object") {
+				connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;
+			}
+
+			if (connection && "saveData" in connection) {
+				assert.isTrue("mob.sd" in b);
+				assert.isTrue(b["mob.sd"] === connection.saveData);
+			}
+		}
+	});
 });

--- a/tests/page-templates/19-mobile/02-mobile-connection-disabled.html
+++ b/tests/page-templates/19-mobile/02-mobile-connection-disabled.html
@@ -1,0 +1,12 @@
+<%= header %>
+<%= boomerangSnippet %>
+<script src="02-mobile-connection-disabled.js" type="text/javascript"></script>
+<script>
+	BOOMR_test.init({
+		testAfterOnBeacon: true,
+		Mobile: {
+		  enabled: false
+		}
+	});
+</script>
+<%= footer %>

--- a/tests/page-templates/19-mobile/02-mobile-connection-disabled.js
+++ b/tests/page-templates/19-mobile/02-mobile-connection-disabled.js
@@ -1,0 +1,23 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/19-mobile/02-mobile-connection-disabled", function() {
+	var t = BOOMR_test;
+	var tf = BOOMR.plugins.TestFramework;
+
+	it("Should pass basic beacon validation", function(done) {
+		t.validateBeaconWasSent(done);
+	});
+
+	it("Should have no keys starting with mob", function() {
+		var k, actual = true, b = tf.beacons[0];
+
+		for (k in b) {
+			if (k.indexOf("mob") === 0) {
+				actual = false;
+			}
+		}
+
+		assert.isTrue(actual);
+	});
+});


### PR DESCRIPTION
The Network Information API is a revision of the `navigator.connection` interface that attempts to provide a standard, cross-browser interface to access information about network conditions. This commit updates the mobile plugin to source network information from the newer source where
available.

This plugin works by first trying to find connection information from various places depending on the browser. It then tries to map data from the identified interface to variables that have historically been used by Boomerang. Effectively, this commit makes Boomerang aware of the new locations of information from the Network Information API.

Credit for this work goes to @bluesmoon, with assistance from @tollmanz to verify and write tests.