### PR TITLE
fix "TypeError: undefined is not an object (evaluating 'target.nodeNa…

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -748,6 +748,7 @@ BOOMR_check_doc_domain();
 				// don't capture events on flash objects
 				// because of context slowdowns in PepperFlash
 				if (target &&
+				    target.nodeName &&
 				    target.nodeName.toUpperCase() === "OBJECT" &&
 				    target.type === "application/x-shockwave-flash") {
 					return;


### PR DESCRIPTION
…me.toUpperCase')"

Error happens on Safari and Mobile Safari 7 and 8